### PR TITLE
[Document fix] eskk#get_stl -> eskk#statusline

### DIFF
--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -236,7 +236,7 @@ g:eskk#initial_mode				*g:eskk#initial_mode*
 g:eskk#statusline_mode_strings		*g:eskk#statusline_mode_strings*
 						(デフォルト値: 下を参照)
 	|'statusline'| に表示される現在のモードの文字列。
-	これは |eskk#get_stl()| の返り値を変える。
+	これは |eskk#statusline()| の返り値を変える。
 
 	デフォルト値は： >
 	let g:eskk#statusline_mode_strings = {

--- a/doc/eskk.txt
+++ b/doc/eskk.txt
@@ -224,7 +224,7 @@ g:eskk#statusline_mode_strings	*g:eskk#statusline_mode_strings*
 							(Default: See below)
 	Current mode's strings at |'statusline'|.
 	Statusline string of modes.
-	This changes |eskk#get_stl()|'s return value.
+	This changes |eskk#statusline()|'s return value.
 
 	Default value is: >
 	let g:eskk#statusline_mode_strings = {


### PR DESCRIPTION
eskk#get_stl was renamed to eskk#statusline
