### PR TITLE
Fix restore formatoptions problem

### DIFF
--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1695,6 +1695,7 @@ function! eskk#_initialize() "{{{
             endif
         endif
     endfunction
+    autocmd eskk InsertLeave * call s:save_restore_formatoptions(0)
     " }}}
 
     " Log startup/shutdown info. {{{
@@ -1781,10 +1782,7 @@ function! eskk#enable() "{{{
     endif
     let inst = eskk#get_current_instance()
 
-    if type(inst.formatoptions) is type(0)
-        let inst.formatoptions = &l:formatoptions
-        let &l:formatoptions = ''
-    endif
+    call s:save_restore_formatoptions(1)
 
     " Clear current variable states.
     let inst.mode = ''
@@ -1834,10 +1832,7 @@ function! eskk#disable() "{{{
     endif
     let inst = eskk#get_current_instance()
 
-    if type(inst.formatoptions) is type("")
-        let &l:formatoptions = inst.formatoptions
-        let inst.formatoptions = 0
-    endif
+    call s:save_restore_formatoptions(0)
 
     " Unmap all lang-mode keymappings.
     call eskk#map#unmap_all_keys()


### PR DESCRIPTION
eskk#disable()が呼ばれなかった場合、formatoptions が復元されないという問題があったので修正しました。
あと、定義されているにもかかわらず呼ばれてなかった formatoptions の復元関数を使うようにしました。
確認をお願いします。
