### PR TITLE
Vim 8への対応とvimprocへの依存の解消

### DIFF
--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1356,7 +1356,7 @@ function! eskk#_initialize() "{{{
     call eskk#util#set_default('g:eskk#debug_wait_ms', 0)
     call eskk#util#set_default('g:eskk#directory', '~/.eskk')
 
-    if exists('g:eskk#server')
+    if exists('g:eskk#server') && !has('channel') && !eskk#util#has_vimproc()
         call eskk#logger#warn(
         \   "eskk.vim: warning: cannot use skkserv " .
         \   "because vimproc is not installed."

--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1356,7 +1356,7 @@ function! eskk#_initialize() "{{{
     call eskk#util#set_default('g:eskk#debug_wait_ms', 0)
     call eskk#util#set_default('g:eskk#directory', '~/.eskk')
 
-    if exists('g:eskk#server') && !eskk#util#has_vimproc()
+    if exists('g:eskk#server')
         call eskk#logger#warn(
         \   "eskk.vim: warning: cannot use skkserv " .
         \   "because vimproc is not installed."

--- a/autoload/eskk/dictionary.vim
+++ b/autoload/eskk/dictionary.vim
@@ -1292,7 +1292,7 @@ function! s:ServerDict_request(command, key) dict "{{{
         if result == ''
             " Reset.
             if has('channel')
-                call ch_evalraw("0\n")
+                call ch_evalraw(self._socket, "0\n")
                 call ch_close(self._socket)
             else
                 call self._socket.write("0\n")

--- a/autoload/eskk/dictionary.vim
+++ b/autoload/eskk/dictionary.vim
@@ -1298,7 +1298,7 @@ function! s:ServerDict_request(command, key) dict "{{{
                 call self._socket.write("0\n")
                 call self._socket.close()
             endif
-            self.init()
+            call self.init()
         endif
     catch
         if has('channel')

--- a/autoload/eskk/dictionary.vim
+++ b/autoload/eskk/dictionary.vim
@@ -1248,10 +1248,23 @@ endfunction "}}}
 
 " Initialize server.
 function! s:ServerDict_init() dict "{{{
-    self._socket = ch_open(self.host, self.port, {'mode': 'nl', 'timeout': self.timeout})
-    if ch_status(self_socket) == "fail"
-		call eskk#logger#warn('server initialization failed.')
-	endif
+    if has('channel')
+        let self._socket = ch_open(printf("%s:%s", self.host, self.port), {'mode': 'nl', 'timeout': self.timeout})
+        if ch_status(self._socket) == "fail"
+            call eskk#logger#warn('server initialization failed.')
+        endif
+    else
+        if !eskk#util#has_vimproc()
+            \ || !vimproc#host_exists(self.host) || self.port <= 0
+                return
+        endif
+
+        try
+            let self._socket = vimproc#socket_open(self.host, self.port)
+        catch
+            call eskk#logger#warn('server initialization failed.')
+        endtry
+    endif
 endfunction "}}}
 
 function! s:ServerDict_request(command, key) dict "{{{
@@ -1264,20 +1277,35 @@ function! s:ServerDict_request(command, key) dict "{{{
         if self.encoding != ''
             let key = iconv(key, &encoding, self.encoding)
         endif
-        let result = ch_evalraw(self._socket, printf("%s%s%s\n",
-        \ a:command, key, (key[strlen(key)-1] != ' ' ? ' ' : '')))
+        if has('channel')
+            let result = ch_evalraw(self._socket, printf("%s%s%s\n",
+            \ a:command, key, (key[strlen(key)-1] != ' ' ? ' ' : '')))
+        else
+            call self._socket.write(printf("%s%s%s\n",
+            \ a:command, key, (key[strlen(key)-1] != ' ' ? ' ' : '')))
+            let result = self._socket.read_line(-1, self.timeout)
+        endif
         if self.encoding != ''
             let result = iconv(result, self.encoding, &encoding)
         endif
 
         if result == ''
             " Reset.
-            call ch_evalraw("0\n")
-            call ch_close(self._socket)
-            call self.init()
+            if has('channel')
+                call ch_evalraw("0\n")
+                call ch_close(self._socket)
+            else
+                call self._socket.write("0\n")
+                call self._socket.close()
+            endif
+            self.init()
         endif
     catch
-        call ch_close(self._socket)
+        if has('channel')
+             call ch_close(self._socket)
+        else
+             call self._socket.close()
+        endif
         return ''
     endtry
 

--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -155,7 +155,7 @@ g:eskk#large_dictionary		*g:eskk#large_dictionary*
 g:eskk#server					*g:eskk#server*
 						(デフォルト値: 下を参照)
 	Skkserv のサーバ情報
-	Note: この機能を使用するためには、|vimproc| が必要。
+	Note: この機能を使用するためには、|channel|か|vimproc| が必要。
 
 	この変数の定義は:
 			辞書型なら:

--- a/doc/eskk.txt
+++ b/doc/eskk.txt
@@ -151,7 +151,7 @@ g:eskk#large_dictionary		*g:eskk#large_dictionary*
 g:eskk#server					*g:eskk#server*
 							(Default: See below)
 	Skkserv information.
-	Note: |vimproc| is required.
+	Note: |channel| or |vimproc| is required.
 
 	This variable value is:
 			Dictionary:


### PR DESCRIPTION
こんにちは。現在の実装ではSKKの辞書サーバーへのアクセスにvimprocのソケット通信が使われています。これをVim 8のChannelに置き換えました。しかしNeovimの非同期通信APIには詳しくなかったので、Channelをサポートしていない場合はvimprocへのフォールバックを行うようにしました。また一通りの動作確認は行っております。よろしくお願いいたします。