### PR TITLE
Fix behavior when one candidate but not exact match

### DIFF
--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -971,7 +971,7 @@ function! s:filter_rom(stash, table) abort "{{{
 
     if preedit.get_henkan_phase() is g:eskk#preedit#PHASE_OKURI
         return s:filter_rom_okuri(a:stash, a:table)
-    elseif a:table.has_n_candidates(rom_str, 2)
+    elseif a:table.waiting_exact_match(rom_str)
         " Has candidates but not match.
         return s:filter_rom_has_candidates(a:stash)
     elseif a:table.has_map(rom_str)
@@ -1055,7 +1055,7 @@ function! s:filter_rom_okuri(stash, table) abort "{{{
     endif
 
     let rom_str = okuri_buf_str.rom_str.get() . char
-    if a:table.has_n_candidates(rom_str, 2)
+    if a:table.waiting_exact_match(rom_str)
         " Has candidates but not match.
         return s:filter_rom_has_candidates(a:stash)
     elseif a:table.has_map(rom_str)

--- a/autoload/eskk/table.vim
+++ b/autoload/eskk/table.vim
@@ -199,6 +199,9 @@ function! s:get_candidates(table, lhs_head, candidates) abort "{{{
     endfor
   endif
 endfunction "}}}
+function! s:AbstractTable_waiting_exact_match(lhs_head) abort dict "{{{
+  return !self.has_map(a:lhs_head) && self.has_candidates(a:lhs_head)
+endfunction "}}}
 
 
 let [
@@ -361,6 +364,7 @@ let s:AbstractTable = {
       \   'has_candidates': eskk#util#get_local_funcref('AbstractTable_has_candidates', s:SID_PREFIX),
       \   'has_n_candidates': eskk#util#get_local_funcref('AbstractTable_has_n_candidates', s:SID_PREFIX),
       \   'get_candidates': eskk#util#get_local_funcref('AbstractTable_get_candidates', s:SID_PREFIX),
+      \   'waiting_exact_match': eskk#util#get_local_funcref('AbstractTable_waiting_exact_match', s:SID_PREFIX),
       \   'has_map': eskk#util#get_local_funcref('AbstractTable_has_map', s:SID_PREFIX),
       \   'get_map': eskk#util#get_local_funcref('AbstractTable_get_map', s:SID_PREFIX),
       \   'has_rest': eskk#util#get_local_funcref('AbstractTable_has_rest', s:SID_PREFIX),


### PR DESCRIPTION
When rom mapping `table.add_map('1.', '1.')` exists
and `table.add_map('1', '1')` does not exist,
`1.` should be converted to `1.` but `1。` .