### PR TITLE
Remove neocomplcache description

### DIFF
--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -58,7 +58,7 @@ eskkは拡張された、そしてさらなる拡張性を秘めたマルチバ�
 
 eskkで実装されている独自機能は主に以下が挙げられます。
 
-* |neocomplcache|, |neocomplete| と連携した自動補完機能
+* |neocomplete| と連携した自動補完機能
 * 改良された改行時の挙動
 * eskkのモード(|eskk-modes|)に応じて、カーソルの色を変更する
 
@@ -313,8 +313,8 @@ g:eskk#marker_jisyo_touroku			*g:eskk#marker_jisyo_touroku*
 g:eskk#enable_completion			*g:eskk#enable_completion*
 							(デフォルト値: 1)
 	もし真なら、eskk組み込みの補完機能を有効にする。
-	|neocomplcache|, |neocomplete| がインストールされている場合、変換時に
-	自動補完が有効になる。
+        |neocomplete| がインストールされている場合、変換時に 自動補完が有効にな
+        る。
 
 g:eskk#max_candidates				*g:eskk#max_candidates*
 							(デフォルト値: 30)

--- a/doc/eskk.txt
+++ b/doc/eskk.txt
@@ -58,7 +58,7 @@ such as multibyte text in Vim.
 
 The remarkable features of eskk is:
 
-* Auto-completion with |neocomplcache|, |neocomplete|
+* Auto-completion with |neocomplete|
 * Improved behavior when a newline inserted
 * Change the cursor's color in each |eskk-modes|
 
@@ -303,7 +303,7 @@ Completion
 g:eskk#enable_completion		*g:eskk#enable_completion*
 							(Default: 1)
 	If true, enables eskk's completion feature.
-	When |neocomplcache| or |neocomplete| is installed,
+	When |neocomplete| is installed,
 	auto-completion feature is enabled.
 
 g:eskk#max_candidates			*g:eskk#max_candidates*


### PR DESCRIPTION
neocomplcache の source は eskk.vim に含まれていない。
実態を考慮し、ドキュメントより neocomplcache の記述は削除するべきである。