### PR TITLE
Update .gitignore to include helptags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.py[cod]
+doc/tags*


### PR DESCRIPTION
When keeping plugins as git sub-modules after generating help tags git status will show uncommitted changes. This should fix by ignoring tags in all languages.

Tested this on my local machine just now:
```
$ git diff
diff --git a/.gitignore b/.gitignore
index 9886e1e..dc74ac0 100644
--- a/.gitignore
+++ b/.gitignore
@@ -1 +1,2 @@
 *.py[cod]
+doc/tags*
```

Where the `doc` folder contains:
```
$ ls doc
eskk.jax
eskk.txt
tags
tags-ja
```