### PR TITLE
fix for Travis CI test

### DIFF
--- a/autoload/eskk/dictionary.vim
+++ b/autoload/eskk/dictionary.vim
@@ -1479,7 +1479,7 @@ function! s:Dictionary_write_lines(lines, verbose) abort dict "{{{
     endif
 
     try
-        call writefile(lines, self._user_dict.path, 's')
+        call writefile(lines, self._user_dict.path, 'ba')
         if a:verbose
             redraw
             echo save_msg . 'Done.'


### PR DESCRIPTION
fix error

https://travis-ci.org/github/tyru/eskk.vim/builds/704176343

```
$ sh /tmp/vim-vimlint/bin/vimlint.sh -l /tmp/vim-vimlint -p /tmp/vim-vimlparser -e EVL103=1 -e EVL102.l:_=1 autoload plugin
autoload/eskk/dictionary.vim:1482:23:Error: EVL108: 3rd argument of writefile should be "ba"
```