### PR TITLE
Fix not a Roman character was removed in filter_rom_no_match #238

### DIFF
--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1185,7 +1185,15 @@ function! s:filter_rom_no_match(stash, table) abort "{{{
         call buf_str.rom_pairs.push_one_pair(char, map, {'converted': 1})
         call buf_str.rom_str.clear()
     else
-        call buf_str.rom_str.set(char)
+        " If typed character isn't a Roman character, it will confirmed.
+        " Because it will be removed in a later phase.
+        if len(a:table.get_candidates(char, [])) == 0
+           \ && g:eskk#rom_input_style ==# 'skk'
+            call buf_str.rom_pairs.push_one_pair(char, char)
+            call buf_str.rom_str.clear()
+        else
+            call buf_str.rom_str.set(char)
+        endif
     endif
 endfunction "}}}
 

--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1185,10 +1185,9 @@ function! s:filter_rom_no_match(stash, table) abort "{{{
         call buf_str.rom_pairs.push_one_pair(char, map, {'converted': 1})
         call buf_str.rom_str.clear()
     else
-        " If typed character isn't a Roman character, it will confirmed.
+        " If typed character isn't a Roman character, it will be confirmed.
         " Because it will be removed in a later phase.
-        if len(a:table.get_candidates(char, [])) == 0
-           \ && g:eskk#rom_input_style ==# 'skk'
+        if empty(a:table.get_candidates(char, [])) && g:eskk#rom_input_style ==# 'skk'
             call buf_str.rom_pairs.push_one_pair(char, char)
             call buf_str.rom_str.clear()
         else


### PR DESCRIPTION
`filter_rom_no_match`のフェーズで入力した全ての文字がローマ字として扱われ、次の文字を入力したり挿入モードを抜けたりした際に削除されてしまうのが今回のバグの原因のようなので、次の文字が処理される段階でローマ字で無ければ確定してしまう修正になります。

文字が入力された瞬間に確定すると複雑になるため、この段階で処理していますが何か問題があれば修正します。
後、コメントを入れていますが英語に自信が無いため確認お願いします。