### PR TITLE
Azik

### DIFF
--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1302,27 +1302,31 @@ function! s:asym_prefilter(stash) abort "{{{
         " 'X' is phase:henkan-select:delete-from-dict
         " 'L' is mode:{hira,kata,hankata}:to-zenei
         return [char]
-    elseif char =~# '^[ZKJDLQHWP]$' && g:eskk#use_azik && g:eskk#azik_enable_precise_shift "{{{
+    elseif char =~# '^[ZKJDLQHWP]$' && g:eskk#use_azik "{{{
         let buf_str = a:stash.preedit.get_current_buf_str()
         if !buf_str.rom_str.empty() && buf_str.rom_pairs.empty()
-            if char ==# 'Z'
-                return ['a', sticky_char, 'nn']
-            elseif char ==# 'K'
-                return ['i', sticky_char, 'nn']
-            elseif char ==# 'J'
-                return ['u', sticky_char, 'nn']
-            elseif char ==# 'D'
-                return ['e', sticky_char, 'nn']
-            elseif char ==# 'L'
-                return ['o', sticky_char, 'nn']
-            elseif char ==# 'Q'
-                return ['a', sticky_char, 'i']
-            elseif char ==# 'H'
-                return ['u', sticky_char, 'u']
-            elseif char ==# 'W'
-                return ['e', sticky_char, 'i']
-            elseif char ==# 'P'
-                return ['o', sticky_char, 'u']
+            if g:eskk#azik_enable_precise_shift
+                if char ==# 'Z'
+                    return ['a', sticky_char, 'nn']
+                elseif char ==# 'K'
+                    return ['i', sticky_char, 'nn']
+                elseif char ==# 'J'
+                    return ['u', sticky_char, 'nn']
+                elseif char ==# 'D'
+                    return ['e', sticky_char, 'nn']
+                elseif char ==# 'L'
+                    return ['o', sticky_char, 'nn']
+                elseif char ==# 'Q'
+                    return ['a', sticky_char, 'i']
+                elseif char ==# 'H'
+                    return ['u', sticky_char, 'u']
+                elseif char ==# 'W'
+                    return ['e', sticky_char, 'i']
+                elseif char ==# 'P'
+                    return ['o', sticky_char, 'u']
+                endif
+            else
+                return [tolower(char)]
             endif
         else
             if char ==# 'L'

--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1302,7 +1302,7 @@ function! s:asym_prefilter(stash) abort "{{{
         " 'X' is phase:henkan-select:delete-from-dict
         " 'L' is mode:{hira,kata,hankata}:to-zenei
         return [char]
-    elseif char =~# '^[ZKJDLQHWP]$' && g:eskk#use_azik "{{{
+    elseif char =~# '^[ZKJDLQHWP]$' && g:eskk#use_azik && g:eskk#azik_enable_precise_shift "{{{
         let buf_str = a:stash.preedit.get_current_buf_str()
         if !buf_str.rom_str.empty() && buf_str.rom_pairs.empty()
             if char ==# 'Z'
@@ -1530,6 +1530,7 @@ function! eskk#_initialize() abort "{{{
 
     " AZIK
     call eskk#util#set_default('g:eskk#use_azik', 0)
+    call eskk#util#set_default('g:eskk#azik_enable_precise_shift', 0)
     call eskk#util#set_default('g:eskk#azik_keyboard_type', 'jp106')
     " }}}
 

--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -433,14 +433,8 @@ g:eskk#use_azik					*g:eskk#use_azik*
 	例1: 社会主義 Xakqxugi
 	Note: 一方、▼モードで誤った単語登録を削除することは出来なくなる。
 
-	Z, K, J, D, L, Q, W, H, Pから始まる送り仮名を変換出来るようになる。~
-	例2: かもめが飛んだ kamomegaTLda
-	例3: さくらが咲いた sakuragaSQta
-	例4: ぱんつを編んだ pztuwoAQda
-	例5: 急いてはことを仕損ずる SWtehaktwoSislZuru
-
 	<S-;>から始まる送り仮名を変換出来るようになる。~
-	例6: くららが立った kuraragaTa<S-;>ta
+	例2: くららが立った kuraragaTa<S-;>ta
 	Note: SKK辞書の仕様上、一般的なAZIKのアルファベットテーブルに加え、
 	以下の定義を追加する必要がある。
 >
@@ -453,11 +447,26 @@ g:eskk#use_azik					*g:eskk#use_azik*
 	アルファベットテーブルについては|eskk-alphabet-table|を参照のこと。
 	また、|vimrc|の設定例は|eskk-faq-use-azik|を参照のこと。
 
-g:eskk#use_azik					*g:eskk#azik_keyboard_type*
+g:eskk#azik_enable_precise_shift		*g:eskk#azik_enable_precise_shift*
+							(デフォルト値: 0)
+	AZIKを使う際、Shiftキーを正確に入力することを前提として、
+	Z, K, J, D, L, Q, W, H, Pから始まる送り仮名を変換出来るようになる。
+	例1: かもめが飛んだ kamomegaTLda
+	例2: さくらが咲いた sakuragaSQta
+	例3: ぱんつを編んだ pztuwoAQda
+	例4: 急いてはことを仕損ずる SWtehaktwoSislZuru
+
+g:eskk#azik_keyboard_type				*g:eskk#azik_keyboard_type*
 							(デフォルト値: "jp106")
 	AZIKを使う際のキーボード配列を指定する。
 	値は"jp106"または"us101"。
-	Note: "us101"を選択した場合、かぎかっこ"「"が入力できなくなる。
+	Note: "us101"を選択した場合、かぎかっこ"「"が入力できなくなるので、
+	例えば以下のとおり別のキーに割り当てる必要がある。
+>
+	let t = eskk#table#new('rom_to_hira*', 'rom_to_hira')
+	call t.add_map('x[', '「')
+	call eskk#register_mode_table('hira', t)
+<
 	(TODO: "jp-pc98"を実装する?)
 
 
@@ -742,7 +751,7 @@ Q. AZIKで入力したいです。
 A. 以下に設定例を示します。 |g:eskk#use_azik| も参照してください。
 なお、アルファベット変換テーブルは長くなりすぎるのでここでは割愛します。
 例えば以下を参照してください。
-https://github.com/hakehash/vimrc/blob/47a31028330b8463ef73e274a733bab269735b9f/.vimrc#L108-L1791
+https://github.com/hakehash/vimrc/blob/9823c5c91522eb5a1534bc81a6304c21d209545c/.vimrc#L112-L1820
 >
 	let g:eskk#use_azik = 1
 	let g:eskk#azik_keyboard_type = 'jp106'


### PR DESCRIPTION
これまではAZIKを使う際、Shiftキーを正確に入力することを前提として、
大文字で入力した文字の次の文字がZ, K, J, D, L, Q, W, H, Pである場合には送り仮名の変換が行われるようにしていましたが、
意図せずShiftキーを押したまま2つの文字を連続して入力してしまう場合もあることから、
変数 g:eskk#azik_enable_precise_shift が1の場合にのみ上記の変換が行われるよう変更しました。
