### PR TITLE
add doc to-ascill unmap for azik

### DIFF
--- a/doc/eskk.jax
+++ b/doc/eskk.jax
@@ -776,12 +776,15 @@ https://github.com/hakehash/vimrc/blob/9823c5c91522eb5a1534bc81a6304c21d209545c/
 	    EskkUnmap -type=mode:hira:toggle-kata q
 	    EskkUnmap -type=mode:hira:q-key q
 	    EskkUnmap -type=mode:hira:l-key l
+	    EskkUnmap -type=mode:hira:to-ascii l
 	    EskkUnmap -type=mode:kata:toggle-kata q
 	    EskkUnmap -type=mode:kata:q-key q
 	    EskkUnmap -type=mode:kata:l-key l
+	    EskkUnmap -type=mode:kata:to-ascii l
 	    EskkUnmap -type=mode:hankata:toggle-kata q
 	    EskkUnmap -type=mode:hankata:q-key q
 	    EskkUnmap -type=mode:hankata:l-key l
+	    EskkUnmap -type=mode:hankata:to-ascii l
 	    EskkUnmap -type=sticky ;
 	    EskkUnmap -type=phase:henkan-select:delete-from-dict X
 	    if g:eskk#azik_keyboard_type=="jp106"


### PR DESCRIPTION
ドキュメントのQ. AZIKで入力したいです。では、以下のように記述されていましたが、この場合変換中以外lから始まるAzikの定義が使用出来ません(li -> ぃ, lwa -> ゎ )
	    EskkUnmap -type=mode:hira:toggle-kata q
	    EskkUnmap -type=mode:hira:q-key q
	    EskkUnmap -type=mode:hira:l-key l
	    EskkUnmap -type=mode:kata:toggle-kata q
	    EskkUnmap -type=mode:kata:q-key q
	    EskkUnmap -type=mode:kata:l-key l
	    EskkUnmap -type=mode:hankata:toggle-kata q
	    EskkUnmap -type=mode:hankata:q-key q
	    EskkUnmap -type=mode:hankata:l-key l
ドキュメントにそのため以下を追加しました
    EskkUnmap -type=mode:hira:to-ascii l
    EskkUnmap -type=mode:kata:to-ascii l
    EskkUnmap -type=mode:hankata:to-ascii l
