### PR TITLE
allow affix behaviors like skkeleton

### DIFF
--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -439,6 +439,9 @@ function! s:asym_filter(stash) abort "{{{
     elseif phase ==# g:eskk#preedit#PHASE_HENKAN
         if char ==# ' '
             call s:do_henkan(a:stash)
+	elseif char ==# '>'
+            call s:filter_rom(a:stash, eskk#get_current_mode_table())
+            call s:do_henkan(a:stash)
         else
             return s:filter_rom(a:stash, eskk#get_current_mode_table())
         endif
@@ -479,6 +482,9 @@ function! s:asym_filter(stash) abort "{{{
                                 \)
                 endif
             endif
+        elseif char ==# '>'
+            call s:do_sticky(a:stash)
+            call s:filter_rom(a:stash, eskk#get_current_mode_table())
         else
             call s:do_enter_egglike(a:stash)
             call preedit.push_filter_queue(char)


### PR DESCRIPTION
接頭辞接尾辞変換をskkeleton風の動作でできるようにしました。

現状でも"Dai> "と入力して接頭辞に変換できますが、>を入力した時点で変換を開始するようにしました。
接尾辞は";bu"で入力できていましたが、こちらも"Ongaku >bu"で>を入力した時点で"音楽"と入力を確定させた上で"▽>ぶ"と変換準備の状態になるようにしました。
