### PR TITLE
Fix g:eskk#keep_state

### DIFF
--- a/autoload/eskk.vim
+++ b/autoload/eskk.vim
@@ -1582,6 +1582,7 @@ function! eskk#_initialize() abort "{{{
     if g:eskk#keep_state
         autocmd eskk InsertEnter * call eskk#map#save_normal_keys()
         autocmd eskk InsertLeave * call eskk#map#restore_normal_keys()
+        autocmd eskk CmdlineEnter * call eskk#disable()
     else
         autocmd eskk InsertLeave * call eskk#disable()
     endif


### PR DESCRIPTION
Disable eskk when CmdlineEnter

Fix #267 

コマンドラインモード遷移時には eskkを無効にするようにして対応します。